### PR TITLE
fix: Use right python environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
-POETRY_RUN := poetry run
+# Workaround for issues in Netlify which started to occur
+# recently
+POETRY := poetry --no-plugins
 
 theme:
 	(ls theme/ > /dev/null && cd theme/ && git pull) || git clone https://github.com/Ecno92/pelican-hyde.git theme/
 
 dev:
-	$(POETRY_RUN) pelican --listen --autoreload
+	$(POETRY) run pelican --listen --autoreload
 
 publish:
-	$(POETRY_RUN) pelican
+	$(POETRY) run pelican
 
 venv:
-	poetry env use $(shell which python3)
-	poetry install
+	$(POETRY) env use $(shell which python3)
+	$(POETRY) install
 
 deploy: venv theme publish
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ publish:
 	$(POETRY_RUN) pelican
 
 venv:
+	poetry env use $(shell which python3)
 	poetry install
 
 deploy: venv theme publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Therry van Neerven <therry.van.neerven@curiousbits.nl>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8.10"
 Markdown = "*"
 pelican = "*"
 markdown = "*"


### PR DESCRIPTION
Even despite adsf did activate python3.8. This was not used by poetry. https://github.com/python-poetry/poetry/issues/655

In the Make target I've added a command which ensures that the right python version is used.